### PR TITLE
Fix system serializer settings dependend deserialization of JsonWebKey

### DIFF
--- a/src/NetDevPack.Security.Jwt.Core/Model/Key.cs
+++ b/src/NetDevPack.Security.Jwt.Core/Model/Key.cs
@@ -28,7 +28,10 @@ public class KeyMaterial
 
     public JsonWebKey GetSecurityKey()
     {
-        return JsonSerializer.Deserialize<JsonWebKey>(Parameters);
+        //problem here are default Serializer options. If these options don't have the property PropertyNameCaseInsensitive = true, the deserialization will fail.
+        //var jsonWebKey = JsonSerializer.Deserialize<JsonWebKey>(Parameters);
+        var jsonWebKey = JsonWebKey.Create(Parameters);
+        return jsonWebKey;
     }
 
     public void Revoke(string reason=default)


### PR DESCRIPTION
As described in #54 , key deserialization may be broken if JsonSerializerOptions are case sensitive